### PR TITLE
feat: PV/PVC/StatefulSet Parser

### DIFF
--- a/docs/development/SPRINT5_PVC_PARSER.md
+++ b/docs/development/SPRINT5_PVC_PARSER.md
@@ -1,0 +1,110 @@
+# Sprint 5: PV/PVC/StatefulSet Parser Implementation
+
+**Issue**: #39 (BACKLOG-4)  
+**Branch**: `feature/sprint5-pvc-parser`  
+**Status**: In Progress
+
+---
+
+## Goal
+Implement parsers for Kubernetes storage resources:
+- PersistentVolumes (PV)
+- PersistentVolumeClaims (PVC)
+- StatefulSets
+
+## Bundle Files to Parse
+
+```
+support-bundle/
+└── rke2/
+    └── kubectl/
+        ├── pv          # kubectl get pv
+        ├── pvc         # kubectl get pvc
+        └── statefulsets  # kubectl get statefulsets
+```
+
+## Implementation Plan
+
+### 1. Data Structures
+Add to `internal/rancher/`:
+
+```go
+// PersistentVolume represents a PV resource
+type PersistentVolume struct {
+    Name          string
+    Status        string // Available, Bound, Released, Failed
+    StorageClass  string
+    Capacity      string
+    Claim         string // namespace/claim-name
+    Age           string
+}
+
+// PersistentVolumeClaim represents a PVC resource
+type PersistentVolumeClaim struct {
+    Name          string
+    Namespace     string
+    Status        string // Pending, Bound, Lost
+    StorageClass  string
+    Capacity      string
+    Volume        string // Bound PV name
+    Age           string
+}
+
+// StatefulSet represents a StatefulSet resource
+type StatefulSet struct {
+    Name          string
+    Namespace     string
+    Replicas      string // ready/total
+    StorageClass  string
+    Age           string
+}
+```
+
+### 2. Parser Functions
+Add to `internal/bundle/kubectl.go`:
+
+```go
+func ParsePVs(extractPath string) ([]rancher.PersistentVolume, error)
+func ParsePVCs(extractPath string) ([]rancher.PersistentVolumeClaim, error)
+func ParseStatefulSets(extractPath string) ([]rancher.StatefulSet, error)
+```
+
+### 3. TUI Integration
+Add to `internal/tui/`:
+- Storage view (new view type)
+- Table display for PV/PVC/StatefulSets
+- Navigation key bindings
+
+### 4. Testing
+- Unit tests for parsers
+- Integration tests with sample data
+
+---
+
+## Progress
+
+- [ ] Data structures defined
+- [ ] PV parser implemented
+- [ ] PVC parser implemented
+- [ ] StatefulSet parser implemented
+- [ ] TUI view added
+- [ ] Tests written
+- [ ] Documentation updated
+
+---
+
+## Notes
+
+Sample kubectl output format:
+
+```
+NAME                                       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+pvc-7f45c8b2-1a2b-4c3d-8e9f-0a1b2c3d4e5f   Bound    pv-1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d   10Gi       RWO            standard       3d
+```
+
+Parsing approach:
+1. Skip header line
+2. Split by whitespace
+3. Map columns to struct fields
+4. Handle missing/empty values
+

--- a/internal/bundle/kubectl.go
+++ b/internal/bundle/kubectl.go
@@ -545,3 +545,122 @@ type DaemonSetInfo struct {
 	Namespace string
 	Ready     string
 }
+
+// ParsePVs parses kubectl get pv output from bundle
+// Format: NAME STATUS VOLUME CAPACITY ACCESS MODES STORAGECLASS AGE
+func ParsePVs(extractPath string) ([]rancher.PersistentVolume, error) {
+	bundleRoot := getBundleRoot(extractPath)
+	path := filepath.Join(bundleRoot, "rke2/kubectl/pv")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(content), "\n")
+	var pvs []rancher.PersistentVolume
+
+	for i, line := range lines {
+		if i == 0 || strings.TrimSpace(line) == "" {
+			continue // Skip header and empty lines
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 6 {
+			continue
+		}
+
+		pv := rancher.PersistentVolume{
+			Name:         fields[0],
+			Status:       fields[1],
+			StorageClass: fields[5],
+			Age:          fields[len(fields)-1],
+		}
+
+		// Capacity is typically field 3
+		if len(fields) > 3 {
+			pv.Capacity = fields[3]
+		}
+
+		// Claim is typically field 4 if format is "namespace/claim-name"
+		if len(fields) > 4 && strings.Contains(fields[4], "/") {
+			pv.Claim = fields[4]
+		}
+
+		pvs = append(pvs, pv)
+	}
+
+	return pvs, nil
+}
+
+// ParsePVCs parses kubectl get pvc output from bundle
+// Format: NAMESPACE NAME STATUS VOLUME CAPACITY ACCESS MODES STORAGECLASS AGE
+func ParsePVCs(extractPath string) ([]rancher.PersistentVolumeClaim, error) {
+	bundleRoot := getBundleRoot(extractPath)
+	path := filepath.Join(bundleRoot, "rke2/kubectl/pvc")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(content), "\n")
+	var pvcs []rancher.PersistentVolumeClaim
+
+	for i, line := range lines {
+		if i == 0 || strings.TrimSpace(line) == "" {
+			continue // Skip header and empty lines
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 7 {
+			continue
+		}
+
+		pvc := rancher.PersistentVolumeClaim{
+			Namespace:    fields[0],
+			Name:         fields[1],
+			Status:       fields[2],
+			Volume:       fields[3],
+			Capacity:     fields[4],
+			StorageClass: fields[len(fields)-2],
+			Age:          fields[len(fields)-1],
+		}
+
+		pvcs = append(pvcs, pvc)
+	}
+
+	return pvcs, nil
+}
+
+// ParseStatefulSets parses kubectl get statefulsets output from bundle
+// Format: NAMESPACE NAME READY AGE
+func ParseStatefulSets(extractPath string) ([]rancher.StatefulSet, error) {
+	bundleRoot := getBundleRoot(extractPath)
+	path := filepath.Join(bundleRoot, "rke2/kubectl/statefulsets")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(content), "\n")
+	var statefulsets []rancher.StatefulSet
+
+	for i, line := range lines {
+		if i == 0 || strings.TrimSpace(line) == "" {
+			continue // Skip header and empty lines
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+
+		statefulsets = append(statefulsets, rancher.StatefulSet{
+			Namespace: fields[0],
+			Name:      fields[1],
+			Replicas:  fields[2],
+			Age:       fields[len(fields)-1],
+		})
+	}
+
+	return statefulsets, nil
+}

--- a/internal/rancher/types.go
+++ b/internal/rancher/types.go
@@ -368,3 +368,33 @@ type Event struct {
 	ObjectKind    string `json:"objectKind"`    // Extracted from Object (e.g., "pod", "node")
 	ContainerName string `json:"containerName"` // Extracted from SubObject (v0.5.6)
 }
+
+// PersistentVolume represents a Kubernetes PersistentVolume
+type PersistentVolume struct {
+	Name         string `json:"name"`
+	Status       string `json:"status"`       // Available, Bound, Released, Failed
+	StorageClass string `json:"storageClass"` // Storage class name
+	Capacity     string `json:"capacity"`     // Storage capacity (e.g., "10Gi")
+	Claim        string `json:"claim"`        // namespace/claim-name
+	Age          string `json:"age"`          // Human-readable age
+}
+
+// PersistentVolumeClaim represents a Kubernetes PersistentVolumeClaim
+type PersistentVolumeClaim struct {
+	Name         string `json:"name"`
+	Namespace    string `json:"namespace"`
+	Status       string `json:"status"`       // Pending, Bound, Lost
+	StorageClass string `json:"storageClass"` // Storage class name
+	Capacity     string `json:"capacity"`     // Storage capacity (e.g., "10Gi")
+	Volume       string `json:"volume"`       // Bound PV name
+	Age          string `json:"age"`          // Human-readable age
+}
+
+// StatefulSet represents a Kubernetes StatefulSet
+type StatefulSet struct {
+	Name         string `json:"name"`
+	Namespace    string `json:"namespace"`
+	Replicas     string `json:"replicas"`     // ready/total format
+	StorageClass string `json:"storageClass"` // Storage class name (if applicable)
+	Age          string `json:"age"`          // Human-readable age
+}


### PR DESCRIPTION
## Summary

Implement parsers for Kubernetes storage resources as requested in #39.

## Changes

### New Data Structures
- `PersistentVolume` - Represents PV resources
- `PersistentVolumeClaim` - Represents PVC resources  
- `StatefulSet` - Represents StatefulSet resources

### New Parser Functions
- `ParsePVs()` - Parses `kubectl get pv` output
- `ParsePVCs()` - Parses `kubectl get pvc` output
- `ParseStatefulSets()` - Parses `kubectl get statefulsets` output

## Testing

- [x] Code compiles successfully
- [ ] Tested with sample bundle data (follow-up PR)
- [ ] TUI integration (follow-up PR)

## Related Issues

Closes #39 (partial - parsers implemented, TUI view pending)

## Checklist

- [x] Code follows project style
- [x] Added documentation
- [x] Build passes locally
- [ ] Tests added (will add in follow-up)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing and displaying Kubernetes storage resources including Persistent Volumes, Persistent Volume Claims, and StatefulSets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->