### PR TITLE
feat: add multi-arch Docker image and GHCR publish workflow (closes #112)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,49 @@
+# =============================================================================
+# .dockerignore for r8s
+# Keeps the Docker build context minimal and prevents unnecessary files
+# from being sent to the Docker daemon during `docker build`.
+# =============================================================================
+
+# ── Version control ───────────────────────────────────────────────────────────
+.git
+.gitignore
+.github
+
+# ── Documentation ─────────────────────────────────────────────────────────────
+*.md
+docs/
+
+# ── Build artifacts ───────────────────────────────────────────────────────────
+bin/
+releases/
+
+# ── Test & coverage ───────────────────────────────────────────────────────────
+coverage.out
+coverage.html
+**/*_test.go
+
+# ── Logs & temp files ─────────────────────────────────────────────────────────
+*.log
+*.tmp
+*.swp
+*.swo
+
+# ── Environment & secrets ─────────────────────────────────────────────────────
+.env
+.env.*
+*.pem
+*.key
+
+# ── OS metadata ───────────────────────────────────────────────────────────────
+.DS_Store
+Thumbs.db
+
+# ── IDE configs ───────────────────────────────────────────────────────────────
+.vscode/
+.idea/
+*.code-workspace
+
+# ── Linter / tool config (not needed at runtime) ─────────────────────────────
+.coderabbit.yaml
+.markdownlint.json
+.golangci.yml

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -115,10 +115,12 @@ jobs:
       # Fix (CodeRabbit): github.repository can contain uppercase characters
       # (e.g. "Rancheroo/r8s") which are invalid in OCI image references.
       # Normalise to lowercase before constructing the docker pull reference.
+      # Fix (CodeRabbit): reuse the already-captured COMMIT from meta_vars
+      # instead of re-running git rev-parse to guarantee tag consistency.
       - name: Smoke test published image
         run: |
           IMAGE_NAME_LOWER=$(echo "${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
-          IMAGE="${{ env.REGISTRY }}/${IMAGE_NAME_LOWER}:sha-$(git rev-parse --short HEAD)"
+          IMAGE="${{ env.REGISTRY }}/${IMAGE_NAME_LOWER}:sha-${{ steps.meta_vars.outputs.COMMIT }}"
 
           echo "=== Pulling image: ${IMAGE} ==="
           docker pull "${IMAGE}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,126 @@
+# Docker Build & Publish Workflow for r8s
+# Resolves: https://github.com/Rancheroo/r8s/issues/112
+#
+# Triggers:
+#   - Push of a versioned tag  (e.g. v0.9.1)
+#   - Manual dispatch          (workflow_dispatch)
+#
+# Publishes to: ghcr.io/rancheroo/r8s
+# Platforms:    linux/amd64, linux/arm64
+
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag override (e.g. v0.9.1-test). Defaults to git ref.'
+        required: false
+        default: ''
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}   # e.g. rancheroo/r8s  (lowercase)
+
+jobs:
+  docker:
+    name: Build & Push Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write   # required to push to GHCR
+
+    steps:
+      # ── 1. Checkout ────────────────────────────────────────────────────────
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so git describe works for VERSION
+
+      # ── 2. Derive version metadata ─────────────────────────────────────────
+      - name: Derive version metadata
+        id: meta_vars
+        run: |
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+          DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          echo "VERSION=${VERSION}"  >> "$GITHUB_OUTPUT"
+          echo "COMMIT=${COMMIT}"    >> "$GITHUB_OUTPUT"
+          echo "DATE=${DATE}"        >> "$GITHUB_OUTPUT"
+
+      # ── 3. Set up QEMU for cross-compilation ───────────────────────────────
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      # ── 4. Set up Docker Buildx ────────────────────────────────────────────
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # ── 5. Log in to GHCR ──────────────────────────────────────────────────
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── 6. Generate image tags & labels ────────────────────────────────────
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # On versioned tag push: v1.2.3, v1.2, v1, latest
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            # Always include the short git SHA for traceability
+            type=sha,prefix=sha-
+            # Manual dispatch: use the user-supplied tag if set
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event.inputs.tag != '' }}
+
+      # ── 7. Build & push multi-arch image ───────────────────────────────────
+      - name: Build and push Docker image
+        id: build_push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Pass version info from git into the build
+          build-args: |
+            VERSION=${{ steps.meta_vars.outputs.VERSION }}
+            COMMIT=${{ steps.meta_vars.outputs.COMMIT }}
+            DATE=${{ steps.meta_vars.outputs.DATE }}
+          # Layer caching to speed up subsequent builds
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # ── 8. Smoke-test the published image ──────────────────────────────────
+      - name: Smoke test published image
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-$(git rev-parse --short HEAD)"
+          echo "=== Pulling image: ${IMAGE} ==="
+          docker pull "${IMAGE}"
+
+          echo "=== Running: r8s --help ==="
+          docker run --rm "${IMAGE}" --help
+
+          echo "=== Running: r8s version ==="
+          docker run --rm "${IMAGE}" version
+
+          echo "✓ Smoke tests passed"
+
+      # ── 9. Print image digest for audit trail ──────────────────────────────
+      - name: Print image digest
+        run: |
+          echo "Image digest: ${{ steps.build_push.outputs.digest }}"
+          echo "Tags pushed:"
+          echo "${{ steps.meta.outputs.tags }}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}   # e.g. rancheroo/r8s  (lowercase)
+  # github.repository is e.g. "Rancheroo/r8s" — lowercased where needed below
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   docker:
@@ -41,10 +42,17 @@ jobs:
           fetch-depth: 0   # full history so git describe works for VERSION
 
       # ── 2. Derive version metadata ─────────────────────────────────────────
+      # Fix (CodeRabbit): prefer the workflow_dispatch input tag when provided;
+      # only fall back to `git describe` when running from an automatic tag push.
       - name: Derive version metadata
         id: meta_vars
         run: |
-          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          DISPATCH_TAG="${{ github.event.inputs.tag }}"
+          if [ -n "${DISPATCH_TAG}" ]; then
+            VERSION="${DISPATCH_TAG}"
+          else
+            VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          fi
           COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
           DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           echo "VERSION=${VERSION}"  >> "$GITHUB_OUTPUT"
@@ -104,9 +112,14 @@ jobs:
           cache-to: type=gha,mode=max
 
       # ── 8. Smoke-test the published image ──────────────────────────────────
+      # Fix (CodeRabbit): github.repository can contain uppercase characters
+      # (e.g. "Rancheroo/r8s") which are invalid in OCI image references.
+      # Normalise to lowercase before constructing the docker pull reference.
       - name: Smoke test published image
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-$(git rev-parse --short HEAD)"
+          IMAGE_NAME_LOWER=$(echo "${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
+          IMAGE="${{ env.REGISTRY }}/${IMAGE_NAME_LOWER}:sha-$(git rev-parse --short HEAD)"
+
           echo "=== Pulling image: ${IMAGE} ==="
           docker pull "${IMAGE}"
 
@@ -116,7 +129,7 @@ jobs:
           echo "=== Running: r8s version ==="
           docker run --rm "${IMAGE}" version
 
-          echo "✓ Smoke tests passed"
+          echo "Smoke tests passed"
 
       # ── 9. Print image digest for audit trail ──────────────────────────────
       - name: Print image digest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,76 @@
+# =============================================================================
+# Dockerfile for r8s — CLI Automation Engine for RKE2 & K3S Triage
+# Resolves: https://github.com/Rancheroo/r8s/issues/112
+#
+# Multi-stage build:
+#   Stage 1 (builder): Compiles a fully static Go binary
+#   Stage 2 (runtime): Minimal alpine image with the r8s binary
+#
+# Build:
+#   docker build -t r8s .
+#
+# Run:
+#   docker run --rm -v $(pwd)/support-bundle:/bundle r8s analyze /bundle
+#
+# Multi-arch build (requires Docker buildx):
+#   docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/rancheroo/r8s:latest .
+# =============================================================================
+
+# ── Stage 1: Build ────────────────────────────────────────────────────────────
+FROM golang:1.23-alpine AS builder
+
+# Install git so `go build` can embed VCS info via ldflags
+RUN apk add --no-cache git ca-certificates
+
+WORKDIR /build
+
+# Cache dependency downloads separately from the source compile step
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the rest of the source
+COPY . .
+
+# Build arguments forwarded from docker build / CI
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG DATE=unknown
+
+# Build a fully static binary:
+#   CGO_ENABLED=0   — no C dependencies
+#   -trimpath       — reproducible builds, removes local path prefixes
+#   -ldflags        — inject version metadata + strip debug symbols (-s -w)
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -trimpath \
+    -ldflags "-s -w \
+              -X main.version=${VERSION} \
+              -X main.commit=${COMMIT} \
+              -X main.date=${DATE}" \
+    -o /build/r8s \
+    main.go
+
+# ── Stage 2: Runtime ──────────────────────────────────────────────────────────
+FROM alpine:3.19
+
+# ca-certificates — needed for HTTPS requests (AI/API features)
+# timezone data   — consistent timestamps in log output
+RUN apk add --no-cache ca-certificates tzdata && \
+    update-ca-certificates
+
+# Run as a non-root user for security best practices
+# uid/gid 65532 mirrors the "nonroot" convention used by distroless images
+RUN addgroup -g 65532 nonroot && \
+    adduser -u 65532 -G nonroot -s /sbin/nologin -D nonroot
+
+COPY --from=builder /build/r8s /usr/local/bin/r8s
+
+# Ensure the binary is executable
+RUN chmod +x /usr/local/bin/r8s
+
+USER nonroot
+
+# Default working directory where users can mount support bundles
+WORKDIR /data
+
+ENTRYPOINT ["/usr/local/bin/r8s"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,14 @@ ARG COMMIT=unknown
 ARG DATE=unknown
 
 # Build a fully static binary:
-#   CGO_ENABLED=0   — no C dependencies
+#   CGO_ENABLED=0   — no C dependencies, fully portable
 #   -trimpath       — reproducible builds, removes local path prefixes
 #   -ldflags        — inject version metadata + strip debug symbols (-s -w)
+#
+# NOTE: use `go build .` (package path) NOT `go build main.go` (file path).
+#       Building a named file skips the linker's package resolution step,
+#       which means -X main.version / -X main.commit / -X main.date are
+#       silently ignored.  Building the package (`.`) applies them correctly.
 RUN CGO_ENABLED=0 GOOS=linux go build \
     -trimpath \
     -ldflags "-s -w \
@@ -47,7 +52,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
               -X main.commit=${COMMIT} \
               -X main.date=${DATE}" \
     -o /build/r8s \
-    main.go
+    .
 
 # ── Stage 2: Runtime ──────────────────────────────────────────────────────────
 FROM alpine:3.19

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,10 +67,9 @@ RUN apk add --no-cache ca-certificates tzdata && \
 RUN addgroup -g 65532 nonroot && \
     adduser -u 65532 -G nonroot -s /sbin/nologin -D nonroot
 
+# The Go compiler sets the executable bit on the output binary automatically.
+# COPY --from=builder preserves those permissions; no chmod layer needed.
 COPY --from=builder /build/r8s /usr/local/bin/r8s
-
-# Ensure the binary is executable
-RUN chmod +x /usr/local/bin/r8s
 
 USER nonroot
 


### PR DESCRIPTION
## Closes #112 — Docker Image for r8s

This PR implements the Docker support requested in issue #112, enabling `r8s` to be used in CI/CD pipelines without requiring a local Go installation.

## Problem

`r8s` had no Docker image, making it difficult to use in automated environments (GitHub Actions, Jenkins). Users had to install the binary manually on each runner.

## Solution

### 1. `Dockerfile` — Multi-Stage Build

| Stage | Base Image | Purpose |
|-------|-----------|---------|
| `builder` | `golang:1.23-alpine` | Compiles a fully static binary (CGO_ENABLED=0) |
| runtime | `alpine:3.19` | Minimal final image |

Key properties:
- Static binary with `-trimpath` for reproducible builds
- - Strips debug symbols with `-ldflags "-s -w"` to keep image lean
- - Version metadata injected via `ARG`/`--build-arg` (VERSION, COMMIT, DATE)
- - Non-root user (uid 65532) following security best practices
- - Entrypoint set to `/usr/local/bin/r8s`; default CMD is `--help`
### 2. `.github/workflows/docker-publish.yml` — GHCR Publish Workflow

- Triggers on versioned tag pushes (`v*.*.*`) and manual dispatch
- - Builds multi-arch image (`linux/amd64`, `linux/arm64`) using Docker Buildx + QEMU
- - Publishes to `ghcr.io/rancheroo/r8s` using `GITHUB_TOKEN` (no extra secrets needed)
- - Smart semver tags: `v1.2.3`, `v1.2`, `v1`, `latest`, `sha-<shortSHA>`
- - GitHub Actions layer cache to speed up rebuilds
- - Smoke test (`r8s --help` + `r8s version`) on the published image
## Usage After Merge

```bash
docker pull ghcr.io/rancheroo/r8s:latest
docker run --rm -v $(pwd)/bundle:/data ghcr.io/rancheroo/r8s:latest analyze /data
```

## How to Verify

```bash
docker build -t r8s:local .
docker run --rm r8s:local --help
docker run --rm r8s:local version
# Verify non-root: uid=65532(nonroot)
docker run --rm r8s:local id
```

## Checklist

- [x] Multi-stage Dockerfile (golang:1.23-alpine + alpine:3.19 runtime)
- [ ] - [x] Multi-arch support (amd64, arm64)
- [ ] - [x] Entrypoint set to `r8s`
- [ ] - [x] Non-root user for security
- [ ] - [x] GHCR publish workflow triggered on release tags
- [ ] - [x] Smoke test in CI workflow
- [ ] - [x] No extra secrets required (uses GITHUB_TOKEN)
- [ ] - [x] Follows `feat:` commit convention from CONTRIBUTING.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated Docker image build and publish with version-based tagging and multi-architecture support.
  * Published images include basic smoke tests and expose a sensible default help command.
  * Runtime images run non-root and are slim for smaller downloads.

* **Chores**
  * Added Docker build configuration and ignore rules to reduce build context and speed builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->