### PR TITLE
feat(internal): create label selector parser and matcher

### DIFF
--- a/internal/labels/selector.go
+++ b/internal/labels/selector.go
@@ -1,0 +1,74 @@
+package labels
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Selector matches labels against requirements.
+type Selector struct {
+	requirements []requirement
+}
+
+type requirement struct {
+	key      string
+	operator string
+	value    string
+}
+
+// Parse parses a selector string into a Selector.
+// Supports "key=value", "key==value", and "key!=value".
+// Multiple requirements are separated by commas (AND logic).
+func Parse(selectorStr string) (*Selector, error) {
+	s := &Selector{}
+	if selectorStr == "" {
+		return s, nil
+	}
+
+	parts := strings.Split(selectorStr, ",")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		var req requirement
+		if strings.Contains(part, "!=") {
+			kv := strings.SplitN(part, "!=", 2)
+			req = requirement{key: strings.TrimSpace(kv[0]), operator: "!=", value: strings.TrimSpace(kv[1])}
+		} else if strings.Contains(part, "==") {
+			kv := strings.SplitN(part, "==", 2)
+			req = requirement{key: strings.TrimSpace(kv[0]), operator: "==", value: strings.TrimSpace(kv[1])}
+		} else if strings.Contains(part, "=") {
+			kv := strings.SplitN(part, "=", 2)
+			req = requirement{key: strings.TrimSpace(kv[0]), operator: "=", value: strings.TrimSpace(kv[1])}
+		} else {
+			return nil, fmt.Errorf("invalid selector requirement: %s", part)
+		}
+
+		if req.key == "" {
+			return nil, fmt.Errorf("invalid selector requirement: key cannot be empty")
+		}
+		s.requirements = append(s.requirements, req)
+	}
+
+	return s, nil
+}
+
+// Matches returns true if the labels satisfy all requirements in the selector.
+func (s *Selector) Matches(labels map[string]string) bool {
+	for _, req := range s.requirements {
+		val, ok := labels[req.key]
+		switch req.operator {
+		case "=", "==":
+			if !ok || val != req.value {
+				return false
+			}
+		case "!=":
+			if ok && val == req.value {
+				return false
+			}
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## 🚀 New Feature

### Problem
Implement a standard Kubernetes-like label selector to parse equality-based requirements and match them against resource labels.

**Severity**: `medium`
**File**: `internal/labels/selector.go`

### Solution
package labels

### Changes
- `internal/labels/selector.go` (new)

### Testing
- [x] Existing tests pass
- [x] Manual review completed
- [x] No new warnings/errors introduced

---


---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Label selector parsing and evaluation now supported, enabling filtering by key-value pairs using equality (=, ==) and inequality (!=) operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->